### PR TITLE
fix: migrate asdf to mise in CI and update golangci-lint

### DIFF
--- a/.github/workflows/ci-backend-e2e.yaml
+++ b/.github/workflows/ci-backend-e2e.yaml
@@ -41,20 +41,14 @@ jobs:
           repository: kamegoro/task-canvas-e2e
           path: task-canvas-e2e
 
-      - name: Set up asdf
-        uses: asdf-vm/actions/setup@v3
+      - name: Set up mise
+        uses: jdx/mise-action@v2
 
       - name: Install k8s-infrastructure tools
         run: |
           cd k8s-infrastructure
-
-          for tool in $(cut -d ' ' -f 1 .tool-versions | sort -u); do
-            echo "Adding plugin for: $tool"
-            asdf plugin-add "$tool" || true
-          done
-
-          asdf install
-          asdf list
+          mise install
+          mise ls
 
       - name: Install task-canvas-e2e tools
         run: |
@@ -64,9 +58,9 @@ jobs:
 
           sdk env install
 
-          asdf plugin add gauge https://github.com/yysushi/asdf-gauge.git
-          asdf install
-          asdf list
+          mise plugins add gauge https://github.com/yysushi/asdf-gauge.git
+          mise install
+          mise ls
 
           echo "JAVA_HOME=$HOME/.sdkman/candidates/java/current" >> $GITHUB_ENV
           echo "$HOME/.sdkman/candidates/java/current/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1
+          version: latest
           working-directory: ./backend
 
       - uses: Jerome1337/gofmt-action@v1.0.5

--- a/.github/workflows/ci-web-e2e.yaml
+++ b/.github/workflows/ci-web-e2e.yaml
@@ -47,21 +47,15 @@ jobs:
           repository: kamegoro/task-canvas-e2e
           path: task-canvas-e2e
 
-      - name: Set up asdf
-        uses: asdf-vm/actions/setup@v3
+      - name: Set up mise
+        uses: jdx/mise-action@v2
 
       - name: Install k8s-infrastructure tools
         run: |
           cd k8s-infrastructure
-
-          for tool in $(cut -d ' ' -f 1 .tool-versions | sort -u); do
-            echo "Adding plugin for: $tool"
-            asdf plugin-add "$tool" || true
-          done
-
-          asdf install
+          mise install
           echo "Installed tools:"
-          asdf list
+          mise ls
 
       - name: Install task-canvas-e2e tools
         run: |
@@ -71,10 +65,10 @@ jobs:
 
           sdk env install
 
-          asdf plugin add gauge https://github.com/yysushi/asdf-gauge.git
-          asdf install
+          mise plugins add gauge https://github.com/yysushi/asdf-gauge.git
+          mise install
           echo "Installed tools:"
-          asdf list
+          mise ls
 
           echo "JAVA_HOME=$HOME/.sdkman/candidates/java/current" >> $GITHUB_ENV
           echo "$HOME/.sdkman/candidates/java/current/bin" >> $GITHUB_PATH


### PR DESCRIPTION
## Summary

- `ci-backend-e2e.yaml` / `ci-web-e2e.yaml`: `asdf-vm/actions/setup@v3` を `jdx/mise-action@v2` に置き換え
  - `asdf-vm/actions/setup@v3` は `ASDF_DIR` 環境変数を設定するだけで `asdf` バイナリを PATH に追加しないため、後続の `run` ステップで `asdf: command not found` が発生していた
  - `jdx/mise-action@v2` は mise のインストールと PATH 追加を正しく処理する
  - `asdf plugin-add/install/list` → `mise plugins add/install/ls` に置き換え
  - mise はデフォルトで `.tool-versions` を読むため k8s-infrastructure 側の変更は不要
- `ci-backend.yaml`: golangci-lint を `v2.1` → `latest` に更新
  - v2.1 は Go 1.24 でビルドされており、プロジェクトの Go 1.25 と非互換でエラーになっていた

## Test plan

- [ ] `lint` (backend) が通ることを確認
- [ ] `backend-e2e` が asdf エラーなく起動することを確認
- [ ] `web-e2e` が asdf エラーなく起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)