### PR TITLE
fix: vitest 4対応のためmockImplementationをアロー関数から通常関数に変更 (Dependabot #1262)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
     "prettier": "3.8.1",
     "storybook": "9.1.15",
     "typescript": "5.9.3",
-    "vitest": "2.1.8",
+    "vitest": "4.1.5",
     "@storybook/addon-docs": "9.1.15"
   },
   "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b"

--- a/frontend/src/hooks/useSignIn.test.ts
+++ b/frontend/src/hooks/useSignIn.test.ts
@@ -6,8 +6,12 @@ import { useSignIn } from '@/hooks/useSignIn';
 const mockSignInExecute = vi.fn();
 
 vi.mock('@/domain/credential', () => {
-  const FakeEmail = vi.fn().mockImplementation((value: string) => ({ value }));
-  const FakePassword = vi.fn().mockImplementation((value: string) => ({ value }));
+  const FakeEmail = vi.fn().mockImplementation(function (value: string) {
+    return { value };
+  });
+  const FakePassword = vi.fn().mockImplementation(function (value: string) {
+    return { value };
+  });
 
   class FakeCredential {
     constructor(

--- a/frontend/src/hooks/useSignUp.test.ts
+++ b/frontend/src/hooks/useSignUp.test.ts
@@ -5,8 +5,12 @@ import { useSignUp } from '@/hooks/useSignUp';
 const mockSignUpExecute = vi.fn();
 
 vi.mock('@/domain/credential', () => {
-  const FakeEmail = vi.fn().mockImplementation((value: string) => ({ value }));
-  const FakePassword = vi.fn().mockImplementation((value: string) => ({ value }));
+  const FakeEmail = vi.fn().mockImplementation(function (value: string) {
+    return { value };
+  });
+  const FakePassword = vi.fn().mockImplementation(function (value: string) {
+    return { value };
+  });
 
   class FakeCredential {
     constructor(


### PR DESCRIPTION
## 概要
- Dependabotがvitestを `2.1.8` から `4.1.5` に更新した
- vitest 4ではアロー関数（コンストラクタになれない）を `mockImplementation` に渡してから `new` で呼び出すことができなくなった
- `useSignIn.test.ts` と `useSignUp.test.ts` で `vi.fn().mockImplementation((value) => ...)` を `vi.fn().mockImplementation(function(value) { return ...; })` に変更

## 確認事項
- [ ] `vitest run src/hooks/` が通ること（ローカル確認済み: 7テストすべて通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)