### PR TITLE
fix: fast-uri / qs / postcss の脆弱性を npm overrides で修正

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11439,34 +11439,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -12186,7 +12158,6 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12506,9 +12477,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,9 @@
     "@rolldown/binding-linux-x64-musl": "1.0.3"
   },
   "overrides": {
-    "fast-uri": "^3.1.2"
+    "fast-uri": "^3.1.2",
+    "qs": "^6.15.2",
+    "postcss": "^8.5.10"
   },
   "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b"
 }


### PR DESCRIPTION
## 概要

Dependabot alerts #97, #98, #124, #89 の npm 脆弱性を修正します。

## 背景 - overrides を使う理由

3件とも**間接依存**（transitive dependency）であるため、直接 `package.json` に書いているパッケージを更新するだけでは解消できません。
npm の公式な解決策は [overrides](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#overrides) です（npm 8.3+ の標準機能）。

| パッケージ | 依存元 | なぜ直接更新できないか |
|---|---|---|
| `fast-uri` | `@storybook/nextjs` → `ajv` → `fast-uri` | `ajv` はさらに間接依存 |
| `qs` | `@storybook/nextjs` → `node-polyfill-webpack-plugin` → `url` → `qs` | `url` パッケージ最新版が `0.11.4` で更新なし |
| `postcss` | `next` 内部依存 | Next.js ��| `postcss` | `next` 内部依存 | Next.js ��| `postcss` | `next` 内部依存 | Next.js ��| `postcss` | `next` 内部依存 | Next.js ��| `postcss` | `next` 内部依存 | Next.js ��| `postcss",| `postccss| `postcss` | `next` 内部依存 | Next.js ��| `postcss` |oses https://github| `postcss` | `next` 内部依存 | epe| `postcss` | `next` 内部依存 | Next.js ��| `postcss` | `next` 内部依存 | Next.js ��| `postcss` | `next` 内部依存 | Next.js ��| `postcss` | `next` 内部依存 | Neme| `postcss` | `next` 内部依存 | Next.js ��| `postcss` | `next` 内部依存 | Next.js ��| `postcss` | `next` 内部依存 | Next.js ��| `postcss` rat| `postcss` | `next` 内部依存 | Next.js ��| `postcss` | `nex 修| `postcss` ョンが存在しないため現時点では対応不可
