### PR TITLE
fix: frontendの細かい技術的負債を解消

### DIFF
--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -41,7 +41,6 @@ const SignUp = () => {
     try {
       setIsLoading(true);
       await signUp(values.email, values.password);
-      setIsLoading(false);
       showSuccess('アカウント作成に成功しました');
 
       router.push('/signin');

--- a/frontend/src/context/DIContext.tsx
+++ b/frontend/src/context/DIContext.tsx
@@ -36,7 +36,7 @@ export const useDI = (): DIContainer => {
 
 const DiProvider = ({ children }: { children: React.ReactNode }) => {
   const diContainer = useMemo<DIContainer>(() => {
-    const apiRouteDriver = new ApiRoutesDriver('http://localhost:3000');
+    const apiRouteDriver = new ApiRoutesDriver('');
 
     const credentialGateway = new CredentialGateway(apiRouteDriver);
     const todoGateway = new TodoGateway(apiRouteDriver);

--- a/frontend/src/useCase/signOutUseCase.ts
+++ b/frontend/src/useCase/signOutUseCase.ts
@@ -1,8 +1,7 @@
-import { User } from '@/domain/user';
 import { SignOutPort } from '@/port/signOutPort';
 
 interface SignOutUseCaseInterface {
-  execute: (user: User) => void;
+  execute: () => void;
 }
 
 export class SignOutUseCase implements SignOutUseCaseInterface {

--- a/frontend/src/useCase/storeTodoUseCase.test.ts
+++ b/frontend/src/useCase/storeTodoUseCase.test.ts
@@ -1,16 +1,26 @@
+import { RegisterTodo, TodoCompleted, TodoContent } from '@/domain/todo';
+import { StoreTodoUseCase } from '@/useCase/storeTodoUseCase';
+
 describe('storeTodoUseCase', () => {
   it('Todoを保存する', async () => {
-    class MockRegisterTodo {
-      getContent = vi.fn();
-      getCompleted = vi.fn();
+    class MockRegisterTodoPort {
       register = vi.fn().mockResolvedValueOnce(undefined);
     }
+    const mockRegisterTodoPort = new MockRegisterTodoPort();
 
-    const mockRegisterTodo = new MockRegisterTodo();
+    const registerTodo = RegisterTodo.factory(
+      new TodoContent('Content 1'),
+      new TodoCompleted(false),
+    );
 
-    const sut = await mockRegisterTodo.register();
+    const sut = await new StoreTodoUseCase(mockRegisterTodoPort).execute(registerTodo);
+    const expected = undefined;
 
-    expect(sut).toEqual(undefined);
-    expect(mockRegisterTodo.register).toHaveBeenCalledTimes(1);
+    expect(sut).toEqual(expected);
+    expect(mockRegisterTodoPort.register).toHaveBeenCalledTimes(1);
+    expect(mockRegisterTodoPort.register).toHaveBeenCalledWith(
+      registerTodo.getContent(),
+      registerTodo.getCompleted(),
+    );
   });
 });

--- a/frontend/src/useCase/updateTodoUseCase.test.ts
+++ b/frontend/src/useCase/updateTodoUseCase.test.ts
@@ -15,7 +15,6 @@ describe('updateTodoUseCase', () => {
       new TodoId('1'),
       new TodoContent('Content 1'),
       new TodoCompleted(false),
-      mockTodoPort,
     );
 
     const sut = await new UpdateTodoUseCase(mockTodoPort).execute(mockTodo);


### PR DESCRIPTION
## Summary
- `signup/page.tsx`: try節内の重複した`setIsLoading(false)`呼び出しを削除（finallyで設定済み）
- `signOutUseCase.ts`: `SignOutUseCaseInterface`のシグネチャを実装(`execute(): void`)に合わせて`execute: () => void`に修正、未使用の`User`importを削除
- `DIContext.tsx`: `ApiRoutesDriver`のハードコードされた`http://localhost:3000`を空文字（相対パス）に修正
- `updateTodoUseCase.test.ts`: `Todo`コンストラクタへの不正な4番目の引数を削除（`tsc`エラーになっていた）
- `storeTodoUseCase.test.ts`: モッククラス単体をテストするだけで`StoreTodoUseCase`自体をテストしていなかったため、`StoreTodoUseCase.execute`を実際にテストするよう書き直し

## Test plan
- [x] `npx vitest run`
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/`