### PR TITLE
fix: CI の paths フィルタに .node-version / .sdkmanrc を追加する

### DIFF
--- a/.github/workflows/ci-backend-e2e.yaml
+++ b/.github/workflows/ci-backend-e2e.yaml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/ci-backend-e2e.yaml"
+      - ".sdkmanrc"
       - "backend/**"
 
 permissions:

--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/ci-backend.yaml"
+      - ".sdkmanrc"
       - "backend/**"
 
 concurrency:

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/ci-lint.yaml"
+      - ".node-version"
       - "frontend/**"
 
 concurrency:

--- a/.github/workflows/ci-next-build.yaml
+++ b/.github/workflows/ci-next-build.yaml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/ci-next-build.yaml"
+      - ".node-version"
       - "frontend/**"
 
 permissions:

--- a/.github/workflows/ci-storybook.yaml
+++ b/.github/workflows/ci-storybook.yaml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/ci-storybook.yaml"
+      - ".node-version"
       - "frontend/**"
 
 permissions:

--- a/.github/workflows/ci-web-e2e.yaml
+++ b/.github/workflows/ci-web-e2e.yaml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/ci-web-e2e.yaml"
+      - ".node-version"
       - "frontend/**"
 
 permissions:


### PR DESCRIPTION
## 概要

Closes #1326

ランタイムバージョンの変更（`.node-version` / `.sdkmanrc`）だけでは CI が一切起動しない問題を修正する。

## 背景

PR #1324（Node.js 23→24）で `.node-version` のみを変更したが、
全 CI ワークフローの `paths` フィルタが `frontend/**` / `backend/**` しか見ておらず、
triage と auto-assign しか走らなかった。

## 変更内容

| ワークフロー | 追加した paths |
|-------------|---------------|
| ci-lint.yaml | `.node-version` |
| ci-next-build.yaml | `.node-version` |
| ci-storybook.yaml | `.node-version` |
| ci-web-e2e.yaml | `.node-version` |
| ci-backend.yaml | `.sdkmanrc` |
| ci-backend-e2e.yaml | `.sdkmanrc` |

## 確認

- [ ] この PR 自体でワークフローファイルが変更されているので CI が起動すること
- [ ] マージ後、`.node-version` のみの変更でフロントエンド CI が起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)