### PR TITLE
ci: add Visual Preview workflow using frameshot GitHub Action

### DIFF
--- a/.github/workflows/visual-preview.yml
+++ b/.github/workflows/visual-preview.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: kamegoro/frameshot@v0.8.0
+      - uses: kamegoro/frameshot@v0.9.0
         with:
           paths: "./frontend/src/_components/**/*.tsx"
           exclude: "*.test.*,*.spec.*,*.stories.*"

--- a/.github/workflows/visual-preview.yml
+++ b/.github/workflows/visual-preview.yml
@@ -1,0 +1,18 @@
+name: Visual Preview
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: kamegoro/frameshot@v0.8.0
+        with:
+          paths: "./frontend/src/_components/**/*.tsx"
+          exclude: "*.test.*,*.spec.*,*.stories.*"


### PR DESCRIPTION
Closes #1331

## Changes

Adds `.github/workflows/visual-preview.yml` that runs on every PR targeting `main`.

Changed `.tsx` components under `frontend/src/_components/**` are automatically:
1. Rendered before/after with full dependency resolution
2. Diffed at pixel level
3. Posted as screenshots in the PR comment

Test/spec/stories files are excluded by default.

## Preview

On the next PR that modifies a component, before/after screenshots will appear automatically in the PR comment — no manual steps required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)