### PR TITLE
ci: auto-approve dependabot patch/minor PRs before auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -18,7 +18,20 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Patch and minor updates are auto-merged after CI passes
+      # Patch and minor updates are auto-approved and auto-merged after CI passes.
+      # Branch protection requires 1 approving review; dependabot[bot] can't
+      # approve its own PR, so nothing was ever satisfying that requirement
+      # and auto-merge sat blocked indefinitely. github-actions[bot] is a
+      # distinct actor from dependabot[bot], so it can supply the approval.
+      - name: Auto-approve patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Auto-merge patch and minor updates
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||


### PR DESCRIPTION
## Summary
- `dependabot-automerge.yml` already enables GitHub's native auto-merge for patch/minor dependabot updates via `gh pr merge --auto`, but branch protection on `main` requires 1 approving review. `dependabot[bot]` can't approve its own PR, so nothing ever satisfied that requirement — auto-merge sat blocked indefinitely and PRs had to be approved/merged by hand.
- Adds an "Auto-approve" step that runs `gh pr review --approve` before enabling auto-merge, scoped to the same patch/minor guard as the merge step. `github-actions[bot]` is a distinct actor from `dependabot[bot]`, so it can supply the required review. Confirmed `can_approve_pull_request_reviews` is already enabled for this repo's Actions permissions, so no additional repo setting change is needed.
- Major version bumps are untouched — they still require a human review as before.

## Test plan
- [ ] Confirm the next patch/minor dependabot PR gets auto-approved by github-actions[bot] and merges automatically once CI is green
- [ ] Confirm a major-version dependabot PR still requires manual review (no auto-approve/auto-merge)